### PR TITLE
Update the proper usage url

### DIFF
--- a/12acb8fe-0573-4ca8-8cc1-180cc6ba3486.md
+++ b/12acb8fe-0573-4ca8-8cc1-180cc6ba3486.md
@@ -3,7 +3,7 @@ The primary and official Youtube profile URL associated with this entity. Links 
 
 ## Example of Proper Usage
 * **[Andreessen Horowitz](https://golden.com/wiki/Andreessen_Horowitz_(a16z)-K4N)** → **Youtube URL** → **https://www.youtube.com/channel/UC9cn0TuPq4dnbTY-CBsm8XA** is correct, is this URL is the primary and official Youtube channel associated with a16z.
-* **[Magnus Carlsen](https://golden.com/wiki/Magnus_Carlsen-ZPKDG)** → **Youtube URL** → **https://www.youtube.com/c/themagnuscarlsen/featured** is correct, as this URL is the primary and official Youtube channel associated with Magnus Carlesen. https://www.youtube.com/c/themagnuscarlsen/about helps confirm this is his official channel.
+* **[Magnus Carlsen](https://golden.com/wiki/Magnus_Carlsen-ZPKDG)** → **Youtube URL** → **https://www.youtube.com/c/themagnuscarlsen** is correct, as this URL is the primary and official Youtube channel associated with Magnus Carlesen. https://www.youtube.com/c/themagnuscarlsen/about helps confirm this is his official channel.
 
 # Example of Improper Usage
 * '[Magnus Carlsen](https://golden.com/wiki/Magnus_Carlsen-ZPKDG)' -> 'Youtube URL' -> 'https://www.youtube.com/watch?v=mVzOdnGz2WM' is incorrect, as this URL is a Youtube video posted by Magnus Carlesen's account, but not the primary and official Youtube profile URL associated with Magnus Carlsen.


### PR DESCRIPTION
The url that was there was over-specified - it led not to the top YouTube channel page but instead a "featured" feature